### PR TITLE
Adaptación a cambios informados por SIOS/REE

### DIFF
--- a/lib/services/datos.dart
+++ b/lib/services/datos.dart
@@ -36,6 +36,7 @@ class Datos {
       'Accept': 'application/json; application/vnd.esios-api-v1+json',
       'Host': 'api.esios.ree.es',
       'Authorization': 'Token token="$token"',
+      'x-api-key': $token,
       'Cookie': '',
     };
     try {


### PR DESCRIPTION
Se ha recibido un email informando de cambios en la API. En lugar de la cabecera Authorization, se va a pasar a usar x-api-key.

Las dos cabeceras pueden coexistir hasta que se realice la migración por parte de REE.

El texto original recibido es:
=================

Como usuario/a del API público de esios api.esios.ree.es, le informamos que se va proceder a la migracion de dicho API a una nueva infraestructura.

El interfaz de todas las operaciones del api se mantendrá sin modificaciones, únicamente se produce un cambio en la cabecera donde se indica el token de acceso a la hora de realizar las llamadas al API.

Actualmente el token de acceso al API se incluye en la siguiente cabecera:

    Authorization: Token token=xxxxxxxxx"


La nueva cabecera a utilizar es la siguiente:

    x-api-key: xxxxxxxxxx


Hemos habilitado el siguiente endpoint de test para que pueda realizar las pruebas necesarias una vez adapte sus llamadas: [https://apip.esios.ree.es](https://apip.esios.ree.es")

Las dos cabeceras son compatibles tanto en el sistema actual como en el nuevo, por lo que ya puede dejar preparados desarrollos con ambas cabeceras si lo desea, y tenerlos actualizados para cuando se despliegue en producción el nuevo sistema.

Se comunicará más adelante la fecha de puesta en producción a través de la web [https://www.esios.ree.es](https://www.esios.ree.es") y por correo electrónico. Si ha adaptado sus llamadas con la nueva cabecera, el cambio debe ser transparente ya que se mantendrá el endpoint https://api.esios.ree.es.